### PR TITLE
Feature/improvestability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.venv/*
+nuki.yaml

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Clone the repository.
 git clone https://github.com/dauden1184/RaspiNukiBridge.git
 ```
 
+Optional: Create virtual environment
+```
+python3 -m venv .venv
+```
+
+Optional: Load virtual environment
+```
+source .venv/bin/activate
+```
+
 Install the requirements.
 ```
 pip install -r requirements.txt

--- a/nuki.py
+++ b/nuki.py
@@ -405,8 +405,7 @@ class Nuki:
                 await self._client.write_gatt_char(characteristic, data)
             except Exception as exc:
                 logger.error(f"Error: {type(exc)} {exc}")
-                #await self.disconnect()
-                await asyncio.sleep(2)
+                await asyncio.sleep(1)
             else:
                 break
         else:
@@ -419,12 +418,11 @@ class Nuki:
             return
         await self.manager.stop_scanning()
         logger.info("Nuki connecting")
-        await self._client.connect(timeout = 30) # default 10s is not enough for nuki TODO: put this into config variable
+        await self._client.connect(timeout = 25) # default 10s is not enough for nuki TODO: put this into config variable
         await self._client.start_notify(BLE_PAIRING_CHAR, self._notification_handler)
         await self._client.start_notify(BLE_SERVICE_CHAR, self._notification_handler)
         logger.info("Connected")
-        # TODO: figure out if we really need this, it might interfere with current execution
-        #self._connection_timeout = asyncio.create_task(self._timeout(30))
+        self._connection_timeout = asyncio.create_task(self._timeout(30))
 
     async def _timeout(self, timeout):
         await asyncio.sleep(timeout)

--- a/nuki.py
+++ b/nuki.py
@@ -405,7 +405,8 @@ class Nuki:
                 await self._client.write_gatt_char(characteristic, data)
             except Exception as exc:
                 logger.error(f"Error: {type(exc)} {exc}")
-                await asyncio.sleep(1)
+                #await self.disconnect()
+                await asyncio.sleep(2)
             else:
                 break
         else:

--- a/nuki.py
+++ b/nuki.py
@@ -180,7 +180,7 @@ class Nuki:
         self._challenge_command = None
         self._pairing_callback = None
         self._connection_timeout = None
-        self.retry = 1
+        self.retry = 3
 
         if nuki_public_key and bridge_private_key:
             self._create_shared_key()
@@ -422,6 +422,7 @@ class Nuki:
         await self._client.start_notify(BLE_PAIRING_CHAR, self._notification_handler)
         await self._client.start_notify(BLE_SERVICE_CHAR, self._notification_handler)
         logger.info("Connected")
+        # TODO: figure out if we really need this, it might interfere with current execution
         #self._connection_timeout = asyncio.create_task(self._timeout(30))
 
     async def _timeout(self, timeout):
@@ -435,7 +436,8 @@ class Nuki:
         if self._connection_timeout:
             self._connection_timeout.cancel()
             self._connection_timeout = None
-        #await self.manager.start_scanning()
+        logger.info("Stopping Scanning")
+        await self.manager.start_scanning()
 
     async def update_state(self):
         logger.info("Updating nuki state")


### PR DESCRIPTION
Hi, 

I tried to improve connection stability. This is still work in progress. 
Main changes: 
 - added venv support to the readme (not really important for connections)
 - pass timeout parameter to connect method and allow up to 30s of timeout (especially this one seems to improve reliability)
 - For now turn off forced disconnect after 30s

@dauden1184 I have a question
1. there is a forced disconnect after 30s (_timeout), what is it used for? I think it's meant for cleaning up but it might still trigger in the middle of another execution. As far as I can see the actions all call disconnect() through _send_data() at the end anyway. So it seems to be redundant and might kill an action if it takes ~30s. 
2. All actions are marked as async. However, bluez seems not to be threadsafe. Might this become an issue, if for example updatestate and lockaction is called at the same time? It seems like if I call another action it runs into trouble. 